### PR TITLE
Fix loading error, reported in #254

### DIFF
--- a/Sensor.dcm
+++ b/Sensor.dcm
@@ -4,6 +4,8 @@ $CMP ADE7758
 D Poly Phase Multifunction Energy Metering, SO-24
 K Energy Metering
 F http://www.analog.com/media/en/technical-documentation/data-sheets/ADE7758.pdf
+$ENDCMP
+#
 $CMP DHT11
 D Temperature and humidity module
 K digital temperature humidity sensor


### PR DESCRIPTION
Just a patch made by the information presented in: https://github.com/KiCad/kicad-symbols/issues/254#issuecomment-361547218

This was done by online editing (not tested though), but my knowledge about the KiCad file format is high enough to know the current file is corrupted and this patch should fix it.